### PR TITLE
Fix misleading link

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <dd>Extended <a href=
           "https://www.w3.org/2002/09/wbs/1/webvr-authoring/">registration deadline</a></dd>
         <dd>
-          <a href="schedule.html">Program announced</a>
+          <a href="agenda.html">Program announced</a>
         </dd>
         <dt>Nov 29, 2017</dt>
         <dd>


### PR DESCRIPTION
Program link led to `schedule.html` instead of `agenda.html`